### PR TITLE
Fix hero text visibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,7 +28,7 @@
     </div>
   </nav>
 
-  <section class="hero text-white">
+  <section class="hero hero-about text-white">
     <div class="container">
       <h1>About Our Company</h1>
       <p>Trusted logistics partner since 1982</p>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,6 +17,38 @@ body {
   color: #fff;
   padding: 120px 0;
   text-align: center;
+  position: relative;
+}
+
+/* Hero image overrides for individual pages */
+.hero-about {
+  background-image: url('../images/pic02.jpg');
+}
+
+.hero-services {
+  background-image: url('../images/pic03.jpg');
+}
+
+.hero-fleet {
+  background-image: url('../images/pic04.jpg');
+}
+
+.hero-contact {
+  background-image: url('../images/banner.jpg');
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.hero .container {
+  position: relative;
 }
 .hero h1 {
   font-size: 3rem;

--- a/contact.html
+++ b/contact.html
@@ -28,7 +28,7 @@
     </div>
   </nav>
 
-  <section class="hero text-white">
+  <section class="hero hero-contact text-white">
     <div class="container">
       <h1>Request a Quote</h1>
       <p>Tell us your transport requirement and we’ll get back to you quickly.</p>

--- a/fleet.html
+++ b/fleet.html
@@ -28,7 +28,7 @@
     </div>
   </nav>
 
-  <section class="hero text-white">
+  <section class="hero hero-fleet text-white">
     <div class="container">
       <h1>Our Fleet</h1>
       <p>A diverse range of vehicles ready for any load</p>

--- a/services.html
+++ b/services.html
@@ -28,7 +28,7 @@
     </div>
   </nav>
 
-  <section class="hero text-white">
+  <section class="hero hero-services text-white">
     <div class="container">
       <h1>Our Services</h1>
       <p>Reliable transport solutions across India</p>


### PR DESCRIPTION
## Summary
- make hero text readable by adding a dark overlay
- use page-specific hero images on about, services, fleet and contact pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68735c35f5748320bc5e7d0d2c51ed1a