### PR TITLE
Reduce gap between hero and About section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -38,7 +38,7 @@ body {
 }
 .hero p {
   font-size: 1.5rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 }
 .section-padding {
   padding: 60px 0;
@@ -52,5 +52,10 @@ footer {
    "Request a Quote" button, stays vertically centered in the viewport. */
 .hero-center {
   height: 100vh;
+}
+
+/* Reduce space between the home hero section and the following section */
+.hero-center + .section-padding {
+  padding-top: 30px;
 }
 

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       </div>
     </div>
   </nav>
-  <section class="hero hero-center py-5 text-center">
+  <section class="hero hero-center pt-5 pb-4 text-center">
     <div class="container">
       <h1>Connecting India, One Route at a Time</h1>
       <p>Dependable transport solutions since 1982</p>


### PR DESCRIPTION
## Summary
- reduce bottom margin of hero paragraph
- add style rule to decrease padding above About section
- tweak hero section spacing in index.html

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e44f01f988320a6b084b68dbfc800