### PR TITLE
Shrink hero section on home page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -51,11 +51,11 @@ footer {
 /* Specific styling for the home page hero so its content, including the
    "Request a Quote" button, stays vertically centered in the viewport. */
 .hero-center {
-  height: 100vh;
+  height: 70vh;
 }
 
 /* Reduce space between the home hero section and the following section */
 .hero-center + .section-padding {
-  padding-top: 30px;
+  padding-top: 20px;
 }
 


### PR DESCRIPTION
## Summary
- trim the hero height so the "About Us" section is visible without scrolling

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687e477a07a08320b090c268e9c86643