### PR TITLE
Add extra fleet icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,23 @@
           <p>For quick deliveries and small loads.</p>
         </div>
       </div>
+<div class="row text-center mb-4">
+  <div class="col-md-4 mb-4">
+    <i class="fa fa-truck-moving fa-2x mb-3 text-primary"></i>
+    <h3>Open Trucks</h3>
+    <p>For goods that don't require enclosure.</p>
+  </div>
+  <div class="col-md-4 mb-4">
+    <i class="fa fa-snowflake fa-2x mb-3 text-primary"></i>
+    <h3>Reefer Trucks</h3>
+    <p>Temperature controlled transport.</p>
+  </div>
+  <div class="col-md-4 mb-4">
+    <i class="fa fa-gas-pump fa-2x mb-3 text-primary"></i>
+    <h3>Tankers</h3>
+    <p>Specialized for liquids and fuel.</p>
+  </div>
+</div>
       <div class="row g-3">
         <div class="col-md-6">
           <img src="images/pic01.jpg" class="img-fluid rounded" alt="Fleet image">


### PR DESCRIPTION
## Summary
- expand "Our Fleet" section
- show additional icons for open trucks, reefer trucks and tankers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e550723fc83209da311915d877325