### PR TITLE
Add header logo

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,10 @@ body {
 .navbar-brand {
   font-weight: 600;
 }
+.navbar-brand img.logo {
+  height: 56px;
+  width: auto;
+}
 .btn-primary {
   background-color: #f39200;
   border-color: #f39200;

--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
 <body>
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
     <div class="container">
-      <a class="navbar-brand" href="index.html">Prakash Transport Service</a>
+      <a class="navbar-brand d-flex align-items-center" href="index.html">
+        <img src="images/PTS Main Logo.png" alt="PTS Logo" class="logo me-2" />
+        Prakash Transport Service
+      </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
## Summary
- show PTS logo in the navbar next to the site name
- style logo appearance in the navigation bar
- enlarge logo so the text within the image is readable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688659c444a88320be82359d73fc6d2f