### PR TITLE
Add terms and privacy pages with footer links

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,10 @@
 
   <footer class="text-center py-4">
     <p class="mb-0">&copy; 2025 Prakash Transport Service. Established 1982.</p>
+    <p class="mb-0">
+      <a href="terms-of-use.html">Terms of Use</a> |
+      <a href="privacy-policy.html">Privacy Policy</a>
+    </p>
   </footer>
 
   <a

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy | Prakash Transport Service</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+  <div class="container py-5">
+    <h1 class="mb-4">Privacy Policy</h1>
+    <p>Prakash Transport Service is committed to protecting the privacy of our
+    customers and visitors. As an MSME operating in India we collect only
+    minimal personal information required to respond to enquiries and to
+    provide transport services.</p>
+    <p>Your name, email address, phone number and shipment details submitted
+    through this website are used solely for communication and booking
+    purposes. We do not sell or share your information with third parties
+    except as necessary to fulfil your transport requirements or if required by
+    law.</p>
+    <p>By providing your details you consent to us contacting you about your
+    logistics needs. You may request to review or delete the data we hold about
+    you at any time by emailing our support team. Our privacy practices follow
+    the guidelines of the Information Technology Act 2000 and related rules in
+    India.</p>
+  </div>
+</body>
+</html>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Terms of Use | Prakash Transport Service</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+  <div class="container py-5">
+    <h1 class="mb-4">Terms of Use</h1>
+    <p>Welcome to Prakash Transport Service. By using this website you agree to the
+    following terms. We provide vehicle hiring and logistics solutions as a
+    Micro, Small and Medium Enterprise (MSME) registered in India.</p>
+    <p>Information on this website is for general guidance only. Quotes,
+    availability and schedules are subject to change based on vehicle
+    conditions and applicable regulations. We strive to keep content accurate
+    but do not guarantee that the website will be free from errors. Users are
+    responsible for verifying details before relying on them.</p>
+    <p>All content and trademarks on this site belong to Prakash Transport
+    Service unless stated otherwise. Unauthorised use or reproduction of any
+    part of the site is prohibited. These terms are governed by the laws of
+    India and disputes will be subject to jurisdiction in India.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `terms-of-use.html` outlining the transport service terms
- create `privacy-policy.html` describing the MSME's privacy practices
- link both pages from the footer of `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68873c9879108320bfaff8073923dc38