### PR TITLE
feat: add dual marquee logo rows and policy pages

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -84,3 +84,55 @@ footer {
   background-color: #1da851;
 }
 
+/* Customer logo marquee */
+.customer-section {
+  background-color: #fff;
+}
+
+.customer-logos {
+  background-color: #fff;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 40px; /* space between rows */
+  padding: 20px 0;
+}
+
+.logos-row {
+  display: flex;
+  align-items: center;
+  gap: 20px; /* reduced space between logos */
+  width: max-content;
+}
+
+.logo-item img {
+  height: 60px;
+  background-color: #fff;
+  object-fit: contain;
+}
+
+.move-left {
+  animation: moveLeft 20s linear infinite;
+}
+
+.move-right {
+  animation: moveRight 20s linear infinite;
+}
+
+@keyframes moveLeft {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes moveRight {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <div class="container">
       <h2 class="text-center mb-5">100+ customers, large and small rely on Prakash Transport Service</h2>
       <div class="customer-logos">
-        <div class="logos-slide logos-slide-left">
+        <div class="logos-row move-right">
           <div class="logo-item"><img src="images/C._H._Robinson-Logo.wine.png" alt="C H Robinson"></div>
           <div class="logo-item"><img src="images/bisleri-logo-png_seeklogo-237556.png" alt="Bisleri"></div>
           <div class="logo-item"><img src="images/Kingfisher.jpg" alt="Kingfisher"></div>
@@ -52,7 +52,8 @@
           <div class="logo-item"><img src="images/Raptakos_Brett-_-Co.png" alt="Raptakos Brett &amp; Co"></div>
           <div class="logo-item"><img src="images/paragon.png" alt="Paragon"></div>
           <div class="logo-item"><img src="images/lovable-india-logo.webp" alt="Lovable India"></div>
-
+        </div>
+        <div class="logos-row move-left">
           <div class="logo-item"><img src="images/Government-Of-India-Logo-Vector.svg-.png" alt="Government of India"></div>
           <div class="logo-item"><img src="images/London-Pilsner-logo.jpeg" alt="London Pilsner"></div>
           <div class="logo-item"><img src="images/Welspun_logo_new_sm_2_1024x1024.webp" alt="Welspun"></div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -9,22 +9,28 @@
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
-  <div class="container py-5">
-    <h1 class="mb-4">Privacy Policy</h1>
-    <p>Prakash Transport Service is committed to protecting the privacy of our
-    customers and visitors. As an MSME operating in India we collect only
-    minimal personal information required to respond to enquiries and to
-    provide transport services.</p>
-    <p>Your name, email address, phone number and shipment details submitted
-    through this website are used solely for communication and booking
-    purposes. We do not sell or share your information with third parties
-    except as necessary to fulfil your transport requirements or if required by
-    law.</p>
-    <p>By providing your details you consent to us contacting you about your
-    logistics needs. You may request to review or delete the data we hold about
-    you at any time by emailing our support team. Our privacy practices follow
-    the guidelines of the Information Technology Act 2000 and related rules in
-    India.</p>
-  </div>
-</body>
+    <div class="container py-5">
+      <h1 class="mb-4">Privacy Policy</h1>
+      <p>Prakash Transport Service is committed to protecting the privacy of our
+      customers and visitors. As an MSME operating in India we collect only
+      minimal personal information required to respond to enquiries and to
+      provide transport services.</p>
+      <p>Your name, email address, phone number and shipment details submitted
+      through this website are used solely for communication and booking
+      purposes. We do not sell or share your information with third parties
+      except as necessary to fulfil your transport requirements or if required by
+      law.</p>
+      <p>We follow the principles of the Digital Personal Data Protection Act,
+      2023 (DPDPA). Personal data is collected and processed only with your
+      consent. You have the right to withdraw consent, and to request access,
+      correction or deletion of the information we hold about you. Requests can
+      be sent to our support team and we will respond within a reasonable
+      timeframe.</p>
+      <p>We retain personal data only for as long as necessary to serve your
+      booking or as mandated by law. Reasonable security safeguards are in place
+      to protect your details, and data is shared with partners solely for
+      service fulfilment. By using our website you consent to this policy and to
+      us contacting you about your logistics needs.</p>
+    </div>
+  </body>
 </html>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -9,20 +9,24 @@
   <link rel="stylesheet" href="assets/css/style.css">
 </head>
 <body>
-  <div class="container py-5">
-    <h1 class="mb-4">Terms of Use</h1>
-    <p>Welcome to Prakash Transport Service. By using this website you agree to the
-    following terms. We provide vehicle hiring and logistics solutions as a
-    Micro, Small and Medium Enterprise (MSME) registered in India.</p>
-    <p>Information on this website is for general guidance only. Quotes,
-    availability and schedules are subject to change based on vehicle
-    conditions and applicable regulations. We strive to keep content accurate
-    but do not guarantee that the website will be free from errors. Users are
-    responsible for verifying details before relying on them.</p>
-    <p>All content and trademarks on this site belong to Prakash Transport
-    Service unless stated otherwise. Unauthorised use or reproduction of any
-    part of the site is prohibited. These terms are governed by the laws of
-    India and disputes will be subject to jurisdiction in India.</p>
-  </div>
-</body>
+    <div class="container py-5">
+      <h1 class="mb-4">Terms of Use</h1>
+      <p>Welcome to Prakash Transport Service. By using this website you agree to the
+      following terms. We provide vehicle hiring and logistics solutions as a
+      Micro, Small and Medium Enterprise (MSME) registered in India.</p>
+      <p>Information on this website is for general guidance only. Quotes,
+      availability and schedules are subject to change based on vehicle
+      conditions and applicable regulations. We strive to keep content accurate
+      but do not guarantee that the website will be free from errors. Users are
+      responsible for verifying details before relying on them.</p>
+      <p>By accessing our services you agree to use this site only for lawful
+      purposes and in a manner that does not inhibit or restrict anyone else's
+      use. We may update these terms at any time, and continued use of the
+      website indicates acceptance of the revised terms.</p>
+      <p>All content and trademarks on this site belong to Prakash Transport
+      Service unless stated otherwise. Unauthorised use or reproduction of any
+      part of the site is prohibited. These terms are governed by the laws of
+      India and disputes will be subject to jurisdiction in India.</p>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- display expanded client list in two counter-scrolling rows with faster animation and matching white background
- flesh out terms of use for transport MSME and cite lawful use expectations
- add DPDPA-aligned privacy policy detailing consent, rights, and retention

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68988ddec158832083a003982ec1b857