### PR TITLE
fix logo rows move simultaneously

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -121,21 +121,28 @@ footer {
   object-fit: contain;
 }
 
-.move-left,
-.move-right {
-  animation: marquee 20s linear infinite;
+.move-left {
+  animation: marquee-left 20s linear infinite;
 }
 
-/* Top row moves left-to-right */
 .move-right {
-  animation-direction: reverse;
+  animation: marquee-right 20s linear infinite;
 }
 
-@keyframes marquee {
+@keyframes marquee-left {
   from {
     transform: translateX(100%);
   }
   to {
     transform: translateX(-100%);
+  }
+}
+
+@keyframes marquee-right {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
   }
 }


### PR DESCRIPTION
## Summary
- animate customer logo rows in opposite directions simultaneously

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f62be128483208598c17edf4a9967