### PR TITLE
Add animated counters to About Us section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -146,3 +146,38 @@ footer {
     transform: translateX(100%);
   }
 }
+
+.counter-row {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.counter-card {
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 30px 20px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  height: 100%;
+}
+
+.counter-number {
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: #f39200;
+}
+
+.counter-label {
+  margin-top: 10px;
+  font-weight: 500;
+  color: #333333;
+}
+
+@media (max-width: 767.98px) {
+  .counter-card {
+    padding: 20px 15px;
+  }
+
+  .counter-number {
+    font-size: 2rem;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -43,6 +43,26 @@
     <div class="container text-center">
       <h2>About Us</h2>
       <p class="lead">For over four decades we have linked businesses with reliable vehicles across the country. Our network of trusted partners ensures your cargo is delivered safely and on time.</p>
+      <div class="row justify-content-center counter-row mt-4">
+        <div class="col-md-4 mb-4">
+          <div class="counter-card">
+            <div class="counter-number" data-target="1000000" data-suffix="+" data-duration="2000">0</div>
+            <p class="counter-label">No. of kms covered</p>
+          </div>
+        </div>
+        <div class="col-md-4 mb-4">
+          <div class="counter-card">
+            <div class="counter-number" data-target="250" data-suffix="+" data-duration="2000">0</div>
+            <p class="counter-label">No. of customers served</p>
+          </div>
+        </div>
+        <div class="col-md-4 mb-4">
+          <div class="counter-card">
+            <div class="counter-number" data-target="95" data-suffix="%+" data-duration="2000">0</div>
+            <p class="counter-label">First Attempt Delivery Rates (FADR)</p>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -202,5 +222,49 @@
   ></a>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    (function () {
+      const counters = document.querySelectorAll('.counter-number');
+      if (!counters.length) return;
+
+      const formatNumber = (value) => value.toLocaleString('en-IN');
+
+      const animateCounter = (counter) => {
+        const target = Number(counter.dataset.target) || 0;
+        const suffix = counter.dataset.suffix || '';
+        const duration = Number(counter.dataset.duration) || 2000;
+        const startTime = performance.now();
+
+        const update = (currentTime) => {
+          const elapsed = currentTime - startTime;
+          const progress = Math.min(elapsed / duration, 1);
+          const currentValue = Math.round(progress * target);
+          counter.textContent = `${formatNumber(currentValue)}${suffix}`;
+
+          if (progress < 1) {
+            requestAnimationFrame(update);
+          } else {
+            counter.textContent = `${formatNumber(target)}${suffix}`;
+          }
+        };
+
+        requestAnimationFrame(update);
+      };
+
+      const observer = new IntersectionObserver(
+        (entries, obs) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              animateCounter(entry.target);
+              obs.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.5 }
+      );
+
+      counters.forEach((counter) => observer.observe(counter));
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add three animated counters to the About Us section highlighting key transport metrics
- style the counter cards to align with the existing design and animate when they enter view

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69104164203883209a897fe1f3f7dc08)